### PR TITLE
Add patch removing "*" from supported extensions

### DIFF
--- a/depends/common/xrick/0001-Remove-from-valid-extensions.patch
+++ b/depends/common/xrick/0001-Remove-from-valid-extensions.patch
@@ -1,0 +1,25 @@
+From 963224e21d1365c00d25a05009e17eda3f013e2c Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Thu, 28 Oct 2021 17:00:44 -0700
+Subject: [PATCH] Remove "*" from valid extensions
+
+---
+ libretro/core/libretro-core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libretro/core/libretro-core.c b/libretro/core/libretro-core.c
+index e24d687..0238dd9 100644
+--- a/libretro/core/libretro-core.c
++++ b/libretro/core/libretro-core.c
+@@ -155,7 +155,7 @@ void retro_get_system_info(struct retro_system_info *info)
+    memset(info, 0, sizeof(*info));
+    info->library_name     = "xrick";
+    info->library_version  = "021212-Dev";
+-   info->valid_extensions = "*|zip";
++   info->valid_extensions = "zip";
+    info->need_fullpath    = true;
+    info->block_extract    = true;
+ }
+-- 
+2.30.2
+

--- a/game.libretro.xrick/addon.xml.in
+++ b/game.libretro.xrick/addon.xml.in
@@ -9,7 +9,7 @@
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">
 		<platforms></platforms>
-		<extensions>*|zip</extensions>
+		<extensions>zip</extensions>
 		<supports_vfs>false</supports_vfs>
 		<supports_standalone>true</supports_standalone>
 		<requires_opengl>false</requires_opengl>


### PR DESCRIPTION
## Description

Currently, the wildcard in the list of extensions is causing failures playing normal media in Kodi, as reported [here](https://github.com/xbmc/xbmc/issues/20329).

Kodi's handling of file extensions is in the process of being rehauled (led by @AlwinEsch ). In the shorter term, Kodi should be made to handle wildcard extensions more gracefully. However, any modifications wouldn't be released until 19.4. Instead, we can temporarily patch the core and upload to the mirrors to fix the problem immediately.

## Screenshots

Before:

![Screenshot from 2021-10-29 08-09-27](https://user-images.githubusercontent.com/531482/139459459-3c488f11-d107-4c06-97fb-d4dde9016580.png)

After:

![Screenshot from 2021-10-29 08-12-05](https://user-images.githubusercontent.com/531482/139459466-2a0ac3ab-433f-4ffd-97d7-cd18e0d86dc7.png)


